### PR TITLE
zack/r10k is moved into puppetlabs/r10k

### DIFF
--- a/R10k.md
+++ b/R10k.md
@@ -29,24 +29,24 @@ mod "profile",
 ```
 # Puppetfile after adding R10k modules
 ```
-mod 'camptocamp/augeas', '1.4.2'
+mod 'camptocamp/augeas', '1.6.0'
 mod 'camptocamp/puppetserver', '2.1.0'
-mod 'croddy/make', '0.0.5'
 mod 'gentoo/portage', '2.3.0'
-mod 'herculesteam/augeasproviders_core', '2.1.2'
-mod 'puppetlabs/apt', '2.2.2'
-mod 'puppetlabs/concat', '2.1.0'
-mod 'puppetlabs/firewall', '1.8.1'
+mod 'herculesteam/augeasproviders_core', '2.1.3'
+mod 'puppetlabs/make', '1.1.0'
+mod 'puppetlabs/r10k', '4.1.0'
+mod 'puppetlabs/apt', '2.3.0'
+mod 'puppetlabs/concat', '2.2.0'
+mod 'puppetlabs/firewall', '1.8.2'
 mod 'puppetlabs/gcc', '0.3.0'
-mod 'puppetlabs/git', '0.4.0'
-mod 'puppetlabs/inifile', '1.5.0'
+mod 'puppetlabs/git', '0.5.0'
+mod 'puppetlabs/inifile', '1.6.0'
 mod 'puppetlabs/pe_gem', '0.2.0'
-mod 'puppetlabs/postgresql', '4.7.1'
+mod 'puppetlabs/postgresql', '4.8.0'
 mod 'puppetlabs/puppetdb', '5.1.2'
-mod 'puppetlabs/ruby', '0.5.0'
-mod 'puppetlabs/stdlib', '4.12.0'
-mod 'puppetlabs/vcsrepo', '1.3.2'
-mod 'zack/r10k', '3.2.0'
+mod 'puppetlabs/ruby', '0.6.0'
+mod 'puppetlabs/stdlib', '4.15.0'
+mod 'puppetlabs/vcsrepo', '1.5.0'
 
 mod "role",
   :git => "git@gitlab.puppetspecialist.nl:puppet/role.git",


### PR DESCRIPTION
This is the updated list I get after I replaced the zack lib with the new one. hope this helps.